### PR TITLE
Add JsonObjectSpanExporter and context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ In the initial version the following utils are provided:
 * ```setup_tracing(name)``` - Sets up basic tracing using  a standardised naming convebstion so that the application is easily identifiable in visualisation tools.
 * ```set_console_exporter()``` - Turns on output of the capturesd traces in a local console/terminal to allow viewing of it without the need for an observability backend such as Jaeger or Promethus. Useful for debugging and testing.
 * ```get_tracer(name)``` - Retrieves the currently active Tracer object and labels is using a standard naming convention so that traces it produces are consistent across applications.
-* ```get_trace_context()``` - Retrives the current trace context (this is just a more clearly named version of the library function).
 * ```get_context_propagator``` - Retrieves the current observability context info in a form suitable for propagating.
 * ```propagate_context_in_stomp_headers(headers, context)``` - Simplfies the propagation of the Tracing Context between services that support STOMP communication over a message bus.
 * ```retrieve_context_from_stomp_headers(frame)``` - Simplifies th reception of the Tracing Context by services that support STOMP communication over a message bus.
 * ```add_span_attributes``` - Simplifies the addition of named attributes to the current span.
+* ```JsonObjectSpanExporter``` - A custom SpanExporter that allows the span content to be examined for use
+in tests.
+* ```asserting_span_exporter``` - A contextmanager that makes use of JsonObjectSpanExporter to allow
+functions under test to be checked by enclosing them in a with block.
 
 Source          | <https://github.com/DiamondLightSource/observability-utils>
 :---:           | :---:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -65,7 +65,7 @@ pydantic-extra-types==2.9.0
 pydantic-settings==2.5.2
 pydantic_core==2.23.4
 Pygments==2.18.0
-pyright==1.1.382
+pyright==1.1.387
 pytest==8.3.3
 pytest-cov==5.0.0
 python-dotenv==1.0.1

--- a/src/observability_utils/tracing/__init__.py
+++ b/src/observability_utils/tracing/__init__.py
@@ -9,7 +9,6 @@ from .decorators import (
 from .helpers import (
     add_span_attributes,
     get_context_propagator,
-    get_trace_context,
     get_tracer,
     propagate_context_in_stomp_headers,
     retrieve_context_from_stomp_headers,
@@ -20,7 +19,6 @@ from .helpers import (
 __all__ = [
     "add_span_attributes",
     "get_context_propagator",
-    "get_trace_context",
     "get_tracer",
     "propagate_context_in_stomp_headers",
     "retrieve_context_from_stomp_headers",

--- a/src/observability_utils/tracing/__init__.py
+++ b/src/observability_utils/tracing/__init__.py
@@ -1,3 +1,7 @@
+from .asserting_exporter import (
+    JsonObjectSpanExporter,
+    asserting_span_exporter,
+)
 from .decorators import (
     start_as_current_span,
     use_propagated_context,
@@ -24,4 +28,6 @@ __all__ = [
     "setup_tracing",
     "start_as_current_span",
     "use_propagated_context",
+    "asserting_span_exporter",
+    "JsonObjectSpanExporter",
 ]

--- a/src/observability_utils/tracing/asserting_exporter.py
+++ b/src/observability_utils/tracing/asserting_exporter.py
@@ -11,10 +11,12 @@ from opentelemetry.sdk.trace.export import (
 
 
 class JsonObjectSpanExporter(SpanExporter):
-    """A custom span exporter to allow spans created by open telemetry tracing code to
-    be examined and verified during normal testing. When using the class it is
-    recommended to use the SimpleSpanProcessor rather than the BatchSpanProcessor to
-    keep the tests quick.
+    """A custom exporter to allow open telemetry spans to be examined
+    and verified during normal testing.
+    The first span that is entered is cached in a Future for retrieval in test code.
+    The span is effectively cleared when it is read, allowing a single instance of the
+    SpanExporter to be reused for multiple tests.
+    It is recommended to use with a SimpleSpanProcessor.
     """
 
     def __init__(

--- a/src/observability_utils/tracing/asserting_exporter.py
+++ b/src/observability_utils/tracing/asserting_exporter.py
@@ -1,0 +1,56 @@
+from collections.abc import Callable, Sequence
+from concurrent.futures import Future
+from contextlib import contextmanager
+from typing import IO
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import (
+    SpanExporter,
+    SpanExportResult,
+)
+
+
+class JsonObjectSpanExporter(SpanExporter):
+    """A custom span exporter to allow spans created by open telemetry tracing code to
+    be examined and verified during normal testing. When using the class it is
+    recommended to use the SimpleSpanProcessor rather than the BatchSpanProcessor to
+    keep the tests quick.
+    """
+
+    def __init__(
+        self,
+        service_name: str | None = "Test",
+        out: IO | None = None,
+        formatter: Callable[[ReadableSpan], str] | None = None,
+    ):
+        self.service_name = service_name
+        self.top_span: Future | None = None
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        if self.top_span is None or self.top_span.done():
+            self.top_span = Future()
+            self.top_span.set_result(spans[-1])
+        return SpanExportResult.SUCCESS
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+
+@contextmanager
+def asserting_span_exporter(
+    exporter: JsonObjectSpanExporter, func_name: str, *span_args: str
+):
+    """Use as a with block around the function under test if decorated with
+    start_as_current_span to check span creation and content.
+
+    params:
+        func_name: The name of the function being tested
+        span_args: The arguments specified in its start_as_current_span decorator
+        or added using Add_span_attributes.
+    """
+    yield
+    if exporter.top_span is not None:
+        span = exporter.top_span.result(timeout=5.0)
+        assert span.name == func_name
+        for param in span_args:
+            assert param in span.attributes

--- a/src/observability_utils/tracing/helpers.py
+++ b/src/observability_utils/tracing/helpers.py
@@ -14,6 +14,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,
     ConsoleSpanExporter,
+    SimpleSpanProcessor,
 )
 from opentelemetry.trace import (
     Tracer,
@@ -52,7 +53,7 @@ def set_console_exporter() -> None:
     exporter so that the raw trace JSON is printed out there.
     """
     provider = cast(TracerProvider, get_tracer_provider())
-    provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
 
 
 def get_tracer(name: str) -> Tracer:

--- a/src/observability_utils/tracing/helpers.py
+++ b/src/observability_utils/tracing/helpers.py
@@ -4,7 +4,7 @@ context proagation setup.
 
 from typing import Any, cast
 
-from opentelemetry.context import Context, get_current
+from opentelemetry.context import Context
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     OTLPSpanExporter,
 )
@@ -68,15 +68,6 @@ def get_tracer(name: str) -> Tracer:
         Tracer: The currently active tracer object.
     """
     return get_tracer_provider().get_tracer("opentelemetry.instrumentation." + name)
-
-
-def get_trace_context() -> Context:
-    """Somewhat redundant but the fn name "get_current" is pretty ambiguous.
-
-    Returns:
-        Context: The retrieved Trace context object for the current trace.
-    """
-    return get_current()
 
 
 def get_context_propagator() -> dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,14 @@ from typing import cast
 
 import pytest
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import get_tracer_provider
 
-from observability_utils.tracing import JsonObjectSpanExporter, setup_tracing
+from observability_utils.tracing import (
+    JsonObjectSpanExporter,
+    set_console_exporter,
+    setup_tracing,
+)
 
 # Prevent pytest from catching exceptions when debugging in vscode so that break on
 # exception works correctly (see: https://github.com/pytest-dev/pytest/issues/7409)
@@ -26,6 +30,6 @@ def trace_provider() -> TracerProvider:
     setup_tracing("tests", False)
     provider = cast(TracerProvider, get_tracer_provider())
     # Use SimpleSpanProcessor to keep tests quick
-    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    set_console_exporter()
     provider.add_span_processor(SimpleSpanProcessor(JsonObjectSpanExporter()))
     return provider

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 import os
+from typing import cast
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.trace import get_tracer_provider
+
+from observability_utils.tracing import JsonObjectSpanExporter, setup_tracing
 
 # Prevent pytest from catching exceptions when debugging in vscode so that break on
 # exception works correctly (see: https://github.com/pytest-dev/pytest/issues/7409)
@@ -13,3 +19,13 @@ if os.getenv("PYTEST_RAISE", "0") == "1":
     @pytest.hookimpl(tryfirst=True)
     def pytest_internalerror(excinfo):
         raise excinfo.value
+
+
+@pytest.fixture(scope="session", autouse=True)
+def trace_provider() -> TracerProvider:
+    setup_tracing("tests", False)
+    provider = cast(TracerProvider, get_tracer_provider())
+    # Use SimpleSpanProcessor to keep tests quick
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    provider.add_span_processor(SimpleSpanProcessor(JsonObjectSpanExporter()))
+    return provider

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,13 +1,8 @@
 import re
 
-import pytest
 from opentelemetry.trace.propagation import get_current_span
 
-from observability_utils.tracing import (
-    get_tracer,
-    set_console_exporter,
-    setup_tracing,
-)
+from observability_utils.tracing import get_tracer
 from observability_utils.tracing.decorators import (
     _attr_path,
     _attr_value_of,
@@ -17,12 +12,6 @@ from observability_utils.tracing.decorators import (
 )
 
 NAME = "test_service"
-
-
-@pytest.fixture()
-def init_tracing():
-    setup_tracing(NAME, False)
-    set_console_exporter()
 
 
 def test_obj_of():
@@ -60,7 +49,7 @@ def test_attr_path():
     assert _attr_path(n) == "multi.part.name"
 
 
-def test_use_propagated_context(init_tracing):
+def test_use_propagated_context():
     trace_id = 164087499969805359226274920435881701965
     span_id = 1836941681154040884
     traceparent_from_ids = "00-7b721a5c2fa681d48b9815c92fe1724d-197e20b9fa4ba434-01"
@@ -79,7 +68,7 @@ def test_use_propagated_context(init_tracing):
     decoratee(carrier)
 
 
-def test_start_as_current_span(init_tracing):
+def test_start_as_current_span():
     @start_as_current_span(
         get_tracer(NAME),
         "param1",
@@ -114,7 +103,7 @@ def test_start_as_current_span(init_tracing):
     decoratee(2, two)
 
 
-def test_start_as_current_span_capturing_args(init_tracing):
+def test_start_as_current_span_capturing_args():
     @start_as_current_span(
         get_tracer(NAME),
         "args",
@@ -131,7 +120,7 @@ def test_start_as_current_span_capturing_args(init_tracing):
     decoratee(2, one)
 
 
-def test_start_as_current_span_capturing_kwargs(init_tracing):
+def test_start_as_current_span_capturing_kwargs():
     @start_as_current_span(
         get_tracer(NAME),
         "kwargs",

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,67 @@
+from typing import cast
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from observability_utils.tracing import (
+    add_span_attributes,
+    asserting_span_exporter,
+    get_tracer,
+    start_as_current_span,
+)
+
+NAME = "test_service"
+
+
+@pytest.fixture()
+def exporter(trace_provider: TracerProvider):
+    processor = cast(
+        BatchSpanProcessor, trace_provider._active_span_processor._span_processors[1]
+    )
+    return processor.span_exporter
+
+
+def test_function_and_param_name_from_decorator_captured(exporter):
+    @start_as_current_span(
+        get_tracer(NAME),
+        "param",
+    )
+    def decoratee(param):
+        pass
+
+    with asserting_span_exporter(exporter, "decoratee", "param"):
+        decoratee(1)
+
+    span = exporter.top_span.result(timeout=0.0)
+    assert len(span.attributes.keys()) == 1
+
+
+def test_param_from_add_span_attributes_also_captured(exporter):
+    @start_as_current_span(
+        get_tracer(NAME),
+        "param1",
+    )
+    def decoratee(param1):
+        add_span_attributes({"other_param": 45})
+        ...
+
+    with asserting_span_exporter(exporter, "decoratee", "param1", "other_param"):
+        decoratee(1)
+
+    span = exporter.top_span.result(timeout=0.0)
+    assert len(span.attributes.keys()) == 2
+
+
+def test_param_from_add_span_attributes_only_captured(exporter):
+    @start_as_current_span(
+        get_tracer(NAME),
+    )
+    def decoratee(param):
+        add_span_attributes({"added_param": 45})
+
+    with asserting_span_exporter(exporter, "decoratee", "added_param"):
+        decoratee(1)
+
+    span = exporter.top_span.result(timeout=0.0)
+    assert len(span.attributes.keys()) == 1

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -32,6 +32,7 @@ def test_function_and_param_name_from_decorator_captured(exporter):
 
     with asserting_span_exporter(exporter, "decoratee", "param"):
         decoratee(1)
+        exporter.force_flush()
 
     span = exporter.top_span.result(timeout=0.0)
     assert len(span.attributes.keys()) == 1
@@ -48,6 +49,7 @@ def test_param_from_add_span_attributes_also_captured(exporter):
 
     with asserting_span_exporter(exporter, "decoratee", "param1", "other_param"):
         decoratee(1)
+        exporter.force_flush()
 
     span = exporter.top_span.result(timeout=0.0)
     assert len(span.attributes.keys()) == 2
@@ -62,6 +64,7 @@ def test_param_from_add_span_attributes_only_captured(exporter):
 
     with asserting_span_exporter(exporter, "decoratee", "added_param"):
         decoratee(1)
+        exporter.force_flush()
 
     span = exporter.top_span.result(timeout=0.0)
     assert len(span.attributes.keys()) == 1

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,44 +1,45 @@
 from typing import cast
 
-import pytest
 from opentelemetry.sdk.trace import Tracer, TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
-from opentelemetry.trace import SpanKind, get_current_span, get_tracer_provider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.trace import SpanKind, get_current_span
 from opentelemetry.trace.span import format_span_id, format_trace_id
 from stomp.utils import Frame
 
 from observability_utils.tracing import (
+    JsonObjectSpanExporter,
     add_span_attributes,
     get_context_propagator,
     get_tracer,
     propagate_context_in_stomp_headers,
     retrieve_context_from_stomp_headers,
-    set_console_exporter,
-    setup_tracing,
 )
 
 TRACEPARENT_KEY = "traceparent"
-NAME = "test_service"
+NAME = "tests"
 PREFIX = "opentelemetry.instrumentation."
 NAME_KEY = "service.name"
+CONSOLE_PROCESSOR_INDEX = 0
+JSON_PROCESSOR_INDEX = 1
 
 
-@pytest.fixture()
-def init_tracing():
-    setup_tracing(NAME, False)
-    set_console_exporter()
+def test_tracing_setup_with_console_exporter(trace_provider: TracerProvider):
+    sp = trace_provider._active_span_processor._span_processors[CONSOLE_PROCESSOR_INDEX]
 
-
-def test_setup_tracing_with_console_exporter(init_tracing):
-    tp = cast(TracerProvider, get_tracer_provider())
-    sp = tp._active_span_processor._span_processors[0]
-
-    assert tp.resource.attributes[NAME_KEY] == NAME
-    assert isinstance(sp, BatchSpanProcessor)
+    assert trace_provider.resource.attributes[NAME_KEY] == NAME
+    assert isinstance(sp, SimpleSpanProcessor)
     assert isinstance(sp.span_exporter, ConsoleSpanExporter)
 
 
-def test_get_context_propagator(init_tracing):
+def test_tracing_setup_with_json_exporter(trace_provider: TracerProvider):
+    sp = trace_provider._active_span_processor._span_processors[JSON_PROCESSOR_INDEX]
+
+    assert trace_provider.resource.attributes[NAME_KEY] == NAME
+    assert isinstance(sp, SimpleSpanProcessor)
+    assert isinstance(sp.span_exporter, JsonObjectSpanExporter)
+
+
+def test_get_context_propagator():
     tr = cast(Tracer, get_tracer(NAME))
     with tr.start_as_current_span("test"):
         span_context = get_current_span().get_span_context()
@@ -51,7 +52,7 @@ def test_get_context_propagator(init_tracing):
     assert carrier[TRACEPARENT_KEY] == traceparent_string
 
 
-def test_propagate_context_in_stomp_headers(init_tracing):
+def test_propagate_context_in_stomp_headers():
     headers = {}
     tr = cast(Tracer, get_tracer(NAME))
     with tr.start_as_current_span("test") as span:
@@ -70,7 +71,7 @@ def test_propagate_context_in_stomp_headers(init_tracing):
     assert attributes["x"] == 4
 
 
-def test_retrieve_context_from_stomp_headers(init_tracing):
+def test_retrieve_context_from_stomp_headers():
     trace_id = 128912953781416571737941496506421356054
     traceparent_string = "00-60fbbb56a2b44e1cd8e7363fb4482616-cebfdbc55ee30d3f-01"
     frame = Frame(cmd=None, headers={TRACEPARENT_KEY: traceparent_string})


### PR DESCRIPTION
Add a custom span exporter to facilitate testing of Spand generated using the start_as_curren_span decorator. Also add a context Manage that uses it.